### PR TITLE
FIX: Added string.h to FileWatcher.h

### DIFF
--- a/keyledsd/include/keyledsd/tools/FileWatcher.h
+++ b/keyledsd/include/keyledsd/tools/FileWatcher.h
@@ -20,6 +20,7 @@
 #include "keyledsd/tools/Event.h"
 #include <functional>
 #include <sys/inotify.h>
+#include <string>
 #include <vector>
 
 namespace keyleds::tools {


### PR DESCRIPTION
this also closes #46 

If you merge this, it would also be nice to enable fedora 30-32 build targets in your opensuse repo. f28 and f29 are since some time EOL ;)