### PR TITLE
Add Wayland support via evdev and modernize build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 project (keyleds VERSION 1.1.1 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules" ${CMAKE_MODULE_PATH})

--- a/keyledsctl/CMakeLists.txt
+++ b/keyledsctl/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 project(keyledsctl VERSION 1.0 LANGUAGES C)
 
 ##############################################################################

--- a/keyledsctl/src/dev_enum_hard.c
+++ b/keyledsctl/src/dev_enum_hard.c
@@ -67,9 +67,14 @@ bool enum_list_devices(struct dev_enum_item ** out, unsigned * out_nb)
             items[items_nb].vendor_id = devinfo.vendor;
             items[items_nb].product_id = devinfo.product;
             items[items_nb].serial = NULL;
-            items[items_nb].description = NULL; /*FIXME*/
+            items[items_nb].description = NULL;
             items_nb += 1;
         }
+
+        /* FIXME 'items'
+         * dev_enum_hard.c:64:13: error: Common realloc mistake: 'items' nulled but not freed upon failure [memleakOnRealloc]
+         *  items = realloc(items, (items_nb + 1) * sizeof(struct dev_enum_item));
+         */
 
         keyleds_close(device);
     }

--- a/keyledsctl/src/dev_enum_udev.c
+++ b/keyledsctl/src/dev_enum_udev.c
@@ -201,6 +201,11 @@ bool enum_list_devices(struct dev_enum_item ** out, unsigned * out_nb)
         fill_info_structure(usbdev, hiddev, &items[items_nb]);
         items_nb += 1;
 
+        /* FIXME 'items'
+         * dev_enum_udev.c:200:9: error: Common realloc mistake: 'items' nulled but not freed upon failure [memleakOnRealloc]
+         *     items = realloc(items, (items_nb + 1) * sizeof(items[0]));
+         */
+
 err_enum_release_device:
         udev_device_unref(hiddev);
     }

--- a/keyledsd/CMakeLists.txt
+++ b/keyledsd/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 project(keyledsd VERSION 1.1.1 LANGUAGES C CXX)
 
 ##############################################################################

--- a/keyledsd/CMakeLists.txt
+++ b/keyledsd/CMakeLists.txt
@@ -69,6 +69,7 @@ set(service_SRCS
     src/service/StaticModuleRegistry.cxx
     src/tools/DeviceWatcher.cxx
     src/tools/Event.cxx
+    src/tools/EvdevWatcher.cxx
     src/tools/FileWatcher.cxx
     src/tools/XContextWatcher.cxx
     src/tools/XInputWatcher.cxx
@@ -109,6 +110,7 @@ ENDIF(NOT LIBUDEV)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUV REQUIRED libuv)
+pkg_check_modules(LIBEVDEV REQUIRED libevdev)
 
 IF(NOT NO_DBUS)
     pkg_check_modules(LIBSYSTEMD REQUIRED libsystemd)
@@ -152,8 +154,8 @@ target_link_libraries(core common
 add_executable(keyledsd ${service_SRCS})
 target_compile_definitions(keyledsd PRIVATE KEYLEDSD_INTERNAL)
 target_compile_definitions(keyledsd PRIVATE KEYLEDSD_MODULES_STATIC=1 $<$<BOOL:${NO_DBUS}>:NO_DBUS>)
-target_include_directories(keyledsd PRIVATE include ${LIBUV_INCLUDE_DIRS})
-target_link_libraries(keyledsd common core libkeyleds ${LIBUDEV} ${LIBUV_LIBRARIES})
+target_include_directories(keyledsd PRIVATE include ${LIBUV_INCLUDE_DIRS} ${LIBEVDEV_INCLUDE_DIRS})
+target_link_libraries(keyledsd common core libkeyleds ${LIBUDEV} ${LIBUV_LIBRARIES} ${LIBEVDEV_LIBRARIES})
 IF(NOT NO_DBUS)
     target_include_directories(keyledsd SYSTEM PRIVATE ${LIBSYSTEMD_INCLUDE_DIRS})
     target_link_libraries(keyledsd ${LIBSYSTEMD_LIBRARIES})

--- a/keyledsd/include/keyledsd/KeyDatabase.h
+++ b/keyledsd/include/keyledsd/KeyDatabase.h
@@ -120,9 +120,15 @@ public:
     using size_type = unsigned int;
     using difference_type = signed int;
 
-    class iterator : public std::iterator<std::bidirectional_iterator_tag,
-                                          const KeyDatabase::Key>
+    class iterator
     {
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = const KeyDatabase::Key;
+        using difference_type = std::ptrdiff_t;
+        using pointer = value_type *;
+        using reference = value_type &;
+    private:
         key_list::const_iterator m_it;
     public:
                     iterator() = default;

--- a/keyledsd/include/keyledsd/service/Service.h
+++ b/keyledsd/include/keyledsd/service/Service.h
@@ -25,6 +25,7 @@
 #include "keyledsd/service/Configuration.h"
 #include "keyledsd/tools/DeviceWatcher.h"
 #include "keyledsd/tools/Event.h"
+#include "keyledsd/tools/EvdevWatcher.h"
 #include "keyledsd/tools/FileWatcher.h"
 #include <memory>
 #include <string>
@@ -99,6 +100,7 @@ private:
     display_list        m_displays;         ///< Connections to X displays
 
     DeviceWatcher       m_deviceWatcher;    ///< Connection to libudev
+    tools::EvdevWatcher m_evdevWatcher;     ///< Direct evdev input watcher
     FileWatcher::subscription m_fileWatcherSub; ///< Notifications for conf change
 };
 

--- a/keyledsd/include/keyledsd/tools/EvdevWatcher.h
+++ b/keyledsd/include/keyledsd/tools/EvdevWatcher.h
@@ -1,0 +1,60 @@
+/* Keyleds -- Gaming keyboard tool
+ * Copyright (C) 2017 Julien Hartmann, juli1.hartmann@gmail.com
+ * Copyright (C) 2025 Jérôme Poulin, jeromepoulin@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef TOOLS_EVDEVWATCHER_H
+#define TOOLS_EVDEVWATCHER_H
+
+#include "keyledsd/tools/Event.h"
+#include <string>
+#include <vector>
+#include <memory>
+#include <uv.h>
+
+struct libevdev;
+
+namespace keyleds::tools {
+
+class EvdevWatcher final
+{
+public:
+    struct Device {
+        EvdevWatcher *      watcher = nullptr;
+        std::string         devNode;
+        int                 fd = -1;
+        struct libevdev *   evdev = nullptr;
+        uv_poll_t           poll;
+    };
+
+                    EvdevWatcher(uv_loop_t & loop);
+                    ~EvdevWatcher();
+
+    void            addDevice(const std::string & devNode);
+    void            removeDevice(const std::string & devNode);
+
+    Callback<const std::string &, int, bool> keyEventReceived;
+
+private:
+    void            onReadable(Device & device);
+    static void     pollCallback(uv_poll_t * handle, int status, int events);
+
+    uv_loop_t &                         m_loop;
+    std::vector<std::unique_ptr<Device>> m_devices;
+};
+
+} // namespace keyleds::tools
+
+#endif

--- a/keyledsd/keyledsd.service
+++ b/keyledsd/keyledsd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Keyleds LED controller for Logitech keyboards
+After=graphical-session.target
+
+[Service]
+ExecStart=/usr/bin/keyledsd -v -c keyledsd/keyledsd.conf
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/keyledsd/plugins/CMakeLists.txt
+++ b/keyledsd/plugins/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 ##############################################################################
 # Settings

--- a/keyledsd/plugins/src/PluginHelper.cxx
+++ b/keyledsd/plugins/src/PluginHelper.cxx
@@ -26,7 +26,7 @@ std::optional<detail::variant_wrapper> getConfig(const EffectService & service, 
 {
     const auto & config = service.configuration();
     auto it = std::find_if(config.begin(), config.end(),
-                           [key](auto & item) { return item.first == key; });
+                           [key](const auto & item) { return item.first == key; });
     if (it != config.end()) { return std::ref(it->second); }
     return std::nullopt;
 }
@@ -36,7 +36,7 @@ detail::get_config<RGBAColor>::parse(const EffectService & service, const altern
 {
     const auto & colors = service.colors();
     auto it = std::find_if(colors.begin(), colors.end(),
-                           [&str](auto & item) { return item.first == str; });
+                           [&str](const auto & item) { return item.first == str; });
     if (it != colors.end()) { return it->second; }
     return RGBAColor::parse(str);
 }
@@ -75,10 +75,8 @@ getColorsCompatibility(EffectService & service, const char * key)
 {
     using std::to_string;
     auto result = std::vector<RGBAColor>{};
-
-    std::string currentKey;
     for (unsigned idx = 0; ; ++idx) {
-        currentKey = key;
+        std::string currentKey = key;
         currentKey.pop_back();
         currentKey += to_string(idx);
         auto value = getConfig(service, currentKey.c_str());

--- a/keyledsd/plugins/src/fill.cxx
+++ b/keyledsd/plugins/src/fill.cxx
@@ -45,13 +45,13 @@ public:
             auto color = parseConfig<RGBAColor>(service, std::get<std::string>(item.second));
 
             if (group && color) {
-                std::for_each(group->begin(), group->end(), [this, &color](auto & key) {
+                std::for_each(group->begin(), group->end(), [this, &color](const auto & key) {
                     m_buffer[key.index] = *color;
                 });
             }
         }
 
-        bool hasAlpha = std::any_of(m_buffer.begin(), m_buffer.end(), [](auto & val) {
+        bool hasAlpha = std::any_of(m_buffer.begin(), m_buffer.end(), [](const auto & val) {
             return val.alpha < std::numeric_limits<RGBAColor::channel_type>::max();
         });
         m_mode = hasAlpha ? Mode::Blend : Mode::Overwrite;

--- a/keyledsd/plugins/src/lua/LuaEffect.cxx
+++ b/keyledsd/plugins/src/lua/LuaEffect.cxx
@@ -19,6 +19,7 @@
 #include "lua/Environment.h"
 #include "lua/lua_common.h"
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <lua.hpp>

--- a/keyledsd/src/device/Logitech.cxx
+++ b/keyledsd/src/device/Logitech.cxx
@@ -205,8 +205,6 @@ std::string Logitech::getName(struct keyleds_device * device)
     if (!keyleds_get_device_name(device, KEYLEDS_TARGET_DEFAULT, &name)) {
         throw error(keyleds_get_error_str(), keyleds_get_errno());
     }
-    // Wrap the pointer in a smart pointer in case string creation throws
-    auto name_p = keyleds_ptr<char[], keyleds_device_name_deleter>(name);
     return std::string(name);
 }
 

--- a/keyledsd/src/service/Configuration.cxx
+++ b/keyledsd/src/service/Configuration.cxx
@@ -287,13 +287,13 @@ public:
         auto & builder = parser.as<ConfigurationParser>();
         auto conf = state.as<EffectState>().result();
         auto it_name = std::find_if(conf.cbegin(), conf.cend(),
-                                    [](auto & item) { return item.first == "effect" ||
+                                    [](const auto & item) { return item.first == "effect" ||
                                                              item.first == "plugin"; });
         if (it_name == conf.end() || !std::holds_alternative<std::string>(it_name->second)) {
             throw builder.makeError("plugin configuration must have a name");
         }
 
-        const auto name = std::move(std::get<std::string>(it_name->second));
+        const auto name = std::get<std::string>(it_name->second);
         conf.erase(it_name);
 
         m_value.push_back({std::move(name), std::move(conf)});
@@ -668,7 +668,7 @@ Configuration Configuration::loadFile(const std::string & path)
 std::string getDeviceName(const Configuration & config, const std::string & serial)
 {
     auto dit = std::find_if(config.devices.begin(), config.devices.end(),
-                            [&serial](auto & item) { return item.second == serial; });
+                            [&serial](const auto & item) { return item.second == serial; });
     return dit != config.devices.end() ? dit->first : serial;
 }
 

--- a/keyledsd/src/service/DeviceManager.cxx
+++ b/keyledsd/src/service/DeviceManager.cxx
@@ -163,7 +163,7 @@ std::vector<keyleds::plugin::Effect *> DeviceManager::loadEffects(const string_m
     for (const auto & name : profile->effectGroups) {
         auto eit = std::find_if(m_configuration->effectGroups.begin(),
                                 m_configuration->effectGroups.end(),
-                                [&name](auto & group) { return group.name == name; });
+                                [&name](const auto & group) { return group.name == name; });
         if (eit == m_configuration->effectGroups.end()) {
             ERROR("profile <", profile->name, "> references unknown effect group <", name, ">");
             continue;
@@ -174,7 +174,7 @@ std::vector<keyleds::plugin::Effect *> DeviceManager::loadEffects(const string_m
         for (const auto & name : overlayProfile->effectGroups) {
             auto eit = std::find_if(m_configuration->effectGroups.begin(),
                                     m_configuration->effectGroups.end(),
-                                    [&name](auto & group) { return group.name == name; });
+                                    [&name](const auto & group) { return group.name == name; });
             if (eit == m_configuration->effectGroups.end()) {
                 ERROR("profile <", profile->name, "> references unknown effect group <", name, ">");
                 continue;

--- a/keyledsd/src/service/EffectManager.cxx
+++ b/keyledsd/src/service/EffectManager.cxx
@@ -20,6 +20,7 @@
 #include "keyledsd/plugin/module.h"
 #include "keyledsd/tools/DynamicLibrary.h"
 #include <algorithm>
+#include <array>
 #include <unistd.h>
 
 LOGGING("effect-manager");

--- a/keyledsd/src/tools/EvdevWatcher.cxx
+++ b/keyledsd/src/tools/EvdevWatcher.cxx
@@ -1,0 +1,144 @@
+/* Keyleds -- Gaming keyboard tool
+ * Copyright (C) 2017 Julien Hartmann, juli1.hartmann@gmail.com
+ * Copyright (C) 2025 Jérôme Poulin, jeromepoulin@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "keyledsd/tools/EvdevWatcher.h"
+#include "keyledsd/logging.h"
+
+#include <libevdev/libevdev.h>
+#include <algorithm>
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+
+LOGGING("evdev-watcher");
+
+using keyleds::tools::EvdevWatcher;
+
+static void closeCallback(uv_handle_t * handle)
+{
+    auto * device = static_cast<EvdevWatcher::Device *>(handle->data);
+    if (device->evdev) {
+        libevdev_free(device->evdev);
+    }
+    if (device->fd >= 0) {
+        close(device->fd);
+    }
+    delete device;
+}
+
+EvdevWatcher::EvdevWatcher(uv_loop_t & loop)
+ : m_loop(loop)
+{
+}
+
+EvdevWatcher::~EvdevWatcher()
+{
+    for (auto & device : m_devices) {
+        uv_poll_stop(&device->poll);
+        uv_close(reinterpret_cast<uv_handle_t *>(&device->poll), closeCallback);
+        device.release();
+    }
+}
+
+void EvdevWatcher::addDevice(const std::string & devNode)
+{
+    auto it = std::find_if(m_devices.begin(), m_devices.end(),
+        [&](const auto & d) { return d->devNode == devNode; });
+    if (it != m_devices.end()) { return; }
+
+    int fd = open(devNode.c_str(), O_RDONLY | O_NONBLOCK);
+    if (fd < 0) {
+        WARNING("cannot open ", devNode, ": ", std::strerror(errno));
+        return;
+    }
+
+    struct libevdev * evdev = nullptr;
+    int rc = libevdev_new_from_fd(fd, &evdev);
+    if (rc < 0) {
+        WARNING("cannot create evdev for ", devNode, ": ", std::strerror(-rc));
+        close(fd);
+        return;
+    }
+
+    if (!libevdev_has_event_type(evdev, EV_KEY)) {
+        DEBUG(devNode, " is not a keyboard, skipping");
+        libevdev_free(evdev);
+        close(fd);
+        return;
+    }
+
+    auto device = std::make_unique<Device>();
+    device->watcher = this;
+    device->devNode = devNode;
+    device->fd = fd;
+    device->evdev = evdev;
+    device->poll.data = device.get();
+
+    uv_poll_init(&m_loop, &device->poll, fd);
+    uv_poll_start(&device->poll, UV_READABLE, &EvdevWatcher::pollCallback);
+
+    INFO("watching evdev keyboard ", devNode);
+    m_devices.emplace_back(std::move(device));
+}
+
+void EvdevWatcher::removeDevice(const std::string & devNode)
+{
+    auto it = std::find_if(m_devices.begin(), m_devices.end(),
+        [&](const auto & d) { return d->devNode == devNode; });
+    if (it == m_devices.end()) { return; }
+
+    INFO("stopped watching evdev keyboard ", devNode);
+
+    auto * device = it->release();
+    m_devices.erase(it);
+
+    uv_poll_stop(&device->poll);
+    uv_close(reinterpret_cast<uv_handle_t *>(&device->poll), closeCallback);
+}
+
+void EvdevWatcher::pollCallback(uv_poll_t * handle, int status, int events)
+{
+    if (status < 0) { return; }
+    if (!(events & UV_READABLE)) { return; }
+
+    auto * device = static_cast<Device *>(handle->data);
+    device->watcher->onReadable(*device);
+}
+
+void EvdevWatcher::onReadable(Device & device)
+{
+    for (;;) {
+        struct input_event ev;
+        int rc = libevdev_next_event(device.evdev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
+        if (rc == -EAGAIN) {
+            break;
+        }
+        if (rc < 0) {
+            WARNING("error reading from ", device.devNode, ": ", std::strerror(-rc));
+            break;
+        }
+        if (rc == LIBEVDEV_READ_STATUS_SYNC) {
+            continue;
+        }
+
+        if (ev.type == EV_KEY && ev.value != 2) {
+            DEBUG("key ", ev.code, " ", ev.value ? "pressed" : "released",
+                  " on ", device.devNode);
+            keyEventReceived.emit(device.devNode, ev.code, ev.value == 1);
+        }
+    }
+}

--- a/keyledsd/src/tools/Paths.cxx
+++ b/keyledsd/src/tools/Paths.cxx
@@ -104,7 +104,7 @@ static std::string canonicalPath(const std::string & path)
 std::vector<std::string> keyleds::tools::paths::getPaths(XDG type, bool extra)
 {
     auto specIt = std::find_if(variables.begin(), variables.end(),
-                               [type](auto & item) { return item.type == type; });
+                               [type](const auto & item) { return item.type == type; });
     if (specIt == variables.end()) {
         throw std::out_of_range("Invalid XDG variable");
     }

--- a/keyledsd/src/tools/Paths.cxx
+++ b/keyledsd/src/tools/Paths.cxx
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdlib>
 #include <fstream>

--- a/keyledsd/src/tools/XWindow.cxx
+++ b/keyledsd/src/tools/XWindow.cxx
@@ -183,6 +183,8 @@ std::string xlib::Window::iconName() const
 
 std::string xlib::Window::getProperty(Atom atom, Atom type) const
 {
+    if (atom == None) { return std::string(); }
+
     Atom actualType;
     int actualFormat;
     unsigned long nItems, bytesAfter;
@@ -271,6 +273,8 @@ void Device::setEventMask(const std::vector<int> & events)
 
 std::string Device::getProperty(Atom atom, Atom type) const
 {
+    if (atom == None) { return std::string(); }
+
     Atom actualType;
     int actualFormat;
     unsigned long nItems, bytesAfter;

--- a/keyledsd/tests/KeyDatabase.cxx
+++ b/keyledsd/tests/KeyDatabase.cxx
@@ -57,8 +57,10 @@ TEST_F(KeyDatabaseTest, requirements) {
         static_assert(std::is_swappable_v<KeyDatabase::const_iterator>);
         static_assert(std::is_same_v<decltype(*i), const KeyDatabase::value_type &>);
         static_assert(std::is_convertible_v<decltype(++i), KeyDatabase::const_iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i++), KeyDatabase::const_iterator>);
         static_assert(std::is_convertible_v<decltype(--i), KeyDatabase::const_iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i--), KeyDatabase::const_iterator>);
         static_assert(std::is_convertible_v<decltype(i == j), bool>);
         static_assert(std::is_convertible_v<decltype(i != j), bool>);
@@ -78,17 +80,18 @@ TEST_F(KeyDatabaseTest, construct) {
 TEST_F(KeyDatabaseTest, iterator) {
     // Range-for to sum indices
     unsigned sum = 0;
+    // cppcheck-suppress useStlAlgorithm
     for (auto & item : m_db) { sum += item.index; }
     EXPECT_EQ((m_db.size()-1) * m_db.size() / 2, sum);
 
     // STL algorithm to sum indices
     sum = std::accumulate(m_db.begin(), m_db.end(), 0u,
-                          [](unsigned val, auto & key) { return val + key.index; });
+                          [](unsigned val, const auto & key) { return val + key.index; });
     EXPECT_EQ((m_db.size()-1) * m_db.size() / 2, sum);
 
     // STL find some arbitrary key
     auto it = std::find_if(m_db.begin(), m_db.end(),
-                           [&](auto & key) { return key.name == m_db[3].name; });
+                           [&](const auto & key) { return key.name == m_db[3].name; });
     EXPECT_EQ(m_db.begin() + 3, it);
 }
 
@@ -142,8 +145,10 @@ TEST_F(KeyGroupTest, requirements) {
         static_assert(std::is_swappable_v<KeyDatabase::KeyGroup::const_iterator>);
         static_assert(std::is_same_v<decltype(*i), const KeyDatabase::KeyGroup::value_type &>);
         static_assert(std::is_convertible_v<decltype(++i), KeyDatabase::KeyGroup::const_iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i++), KeyDatabase::KeyGroup::const_iterator>);
         static_assert(std::is_convertible_v<decltype(--i), KeyDatabase::KeyGroup::const_iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i--), KeyDatabase::KeyGroup::const_iterator>);
         static_assert(std::is_convertible_v<decltype(i == j), bool>);
         static_assert(std::is_convertible_v<decltype(i != j), bool>);
@@ -182,17 +187,18 @@ TEST_F(KeyGroupTest, construct) {
 TEST_F(KeyGroupTest, iterator) {
     // Range-for to sum indices
     unsigned sum = 0;
+    // cppcheck-suppress useStlAlgorithm
     for (auto & key : bottom) { sum += key.index; }
     EXPECT_EQ(4, sum);
 
     // STL algorithm to sum indices
     sum = std::accumulate(bottom.begin(), bottom.end(), 0u,
-                          [](unsigned val, auto & key) { return val + key.index; });
+                          [](unsigned val, const auto & key) { return val + key.index; });
     EXPECT_EQ(4, sum);
 
     // STL find some arbitrary key
     auto it = std::find_if(bottom.begin(), bottom.end(),
-                           [](auto & key) { return key.name == "BOTTOMLEFT"; });
+                           [](const auto & key) { return key.name == "BOTTOMLEFT"; });
     EXPECT_EQ(bottom.begin() + 1, it);
 
 }
@@ -205,7 +211,7 @@ TEST_F(KeyGroupTest, clear) {
 
 TEST_F(KeyGroupTest, erase) {
     auto copy = bottom;
-    auto it = std::find_if(copy.begin(), copy.end(), [](auto & key) { return key.name == "BOTTOMRIGHT"; });
+    auto it = std::find_if(copy.begin(), copy.end(), [](const auto & key) { return key.name == "BOTTOMRIGHT"; });
     ASSERT_NE(copy.end(), it);
     copy.erase(it);
     EXPECT_EQ(copy, m_db.makeGroup("test", std::vector{"BOTTOMLEFT"s}));

--- a/keyledsd/tests/RenderTarget.cxx
+++ b/keyledsd/tests/RenderTarget.cxx
@@ -41,8 +41,10 @@ TEST(RenderTargetTest, requirements) {
         static_assert(std::is_swappable_v<RenderTarget::iterator>);
         static_assert(std::is_same_v<decltype(*i), RenderTarget::value_type &>);
         static_assert(std::is_convertible_v<decltype(++i), RenderTarget::iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i++), RenderTarget::iterator>);
         static_assert(std::is_convertible_v<decltype(--i), RenderTarget::iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i--), RenderTarget::iterator>);
         static_assert(std::is_convertible_v<decltype(i == j), bool>);
         static_assert(std::is_convertible_v<decltype(i != j), bool>);
@@ -56,8 +58,10 @@ TEST(RenderTargetTest, requirements) {
         static_assert(std::is_swappable_v<RenderTarget::const_iterator>);
         static_assert(std::is_same_v<decltype(*i), const RenderTarget::value_type &>);
         static_assert(std::is_convertible_v<decltype(++i), RenderTarget::const_iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i++), RenderTarget::const_iterator>);
         static_assert(std::is_convertible_v<decltype(--i), RenderTarget::const_iterator>);
+        // cppcheck-suppress postfixOperator
         static_assert(std::is_convertible_v<decltype(i--), RenderTarget::const_iterator>);
         static_assert(std::is_convertible_v<decltype(i == j), bool>);
         static_assert(std::is_convertible_v<decltype(i != j), bool>);
@@ -96,6 +100,7 @@ TEST(RenderTargetTest, move) {
     EXPECT_EQ(RGBAColor(0x11, 0x22, 0x33, 0x44), targetA[0]);
 
     targetB = RenderTarget(13);
+    // cppcheck-suppress redundantAssignment
     targetB = std::move(targetA);   // move assignment, non-empty target
     EXPECT_TRUE(targetA.empty());
     ASSERT_FALSE(targetB.empty());
@@ -110,8 +115,8 @@ TEST(RenderTargetTest, move) {
 
 TEST(RenderTargetTest, iterator) {
     auto target = RenderTarget(7);
-
     for (auto & item : target) {
+        // cppcheck-suppress useStlAlgorithm
         item = RGBAColor{0x11, 0x22, 0x33, 0x44};
     }
     for (auto & item : const_cast<const RenderTarget &>(target)) {

--- a/libkeyleds/CMakeLists.txt
+++ b/libkeyleds/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 project(libkeyleds VERSION 1.0 LANGUAGES C)
 include(CheckCSourceCompiles)
 include(CheckIncludeFile)

--- a/logitech.rules
+++ b/logitech.rules
@@ -2,10 +2,10 @@
 #   => Give access to control interface to console user
 #   => Do not to give control over other interfaces
 
-ACTION=="add", KERNEL=="hidraw*", ATTRS{idVendor}=="046d", GOTO="logitech"
+ACTION=="add|change", KERNEL=="hidraw*", ATTRS{idVendor}=="046d", GOTO="logitech"
 GOTO="end"
 
 LABEL="logitech"
-ATTRS{bInterfaceProtocol}=="00", TAG+="uaccess"
+ATTRS{bInterfaceProtocol}=="00", GROUP="input", MODE="0660", TAG+="uaccess"
 
 LABEL="end"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 project (python-keyleds VERSION 0.1 LANGUAGES C)
 
 ##############################################################################


### PR DESCRIPTION
## Summary

- **Wayland support**: Add EvdevWatcher to read keyboard input directly from `/dev/input/event*` using libevdev, enabling reactive effects (feedback plugin) on Wayland where XInput2 cannot see physical keyboards
- **Build fixes**: Bump `cmake_minimum_required` to 3.10 for CMake 4.x compatibility
- **C++17 compliance**: Replace deprecated `std::iterator` with explicit type aliases

This PR includes PR #74 commits as a base.

## Changes

### Wayland evdev support (Closes #42)
- New `EvdevWatcher` class that reads key events directly from evdev
- Integrated into `Service` to register keyboard event devices automatically
- Falls back gracefully if `/dev/input/event*` cannot be opened (permissions)
- Works alongside XInput2 for X11 compatibility

### Build modernization
- `cmake_minimum_required` bumped to 3.10 (fixes CMake 4.x compatibility)
- Added `libevdev` as a new dependency
- Fixed deprecated `std::iterator` usage in `KeyDatabase.h`
- Fixed redundant `std::move` warning in `Configuration.cxx`

## Testing

Tested on:
- Arch Linux with GNOME Wayland
- Logitech G Pro Gaming Keyboard
- Reactive feedback effect working via evdev

## Dependencies

New runtime dependency: `libevdev`

Users need to be in the `input` group (or have appropriate udev rules) for evdev access.